### PR TITLE
Use insertAdjacentHTML instead of createElement

### DIFF
--- a/js/search-engine-settings.js
+++ b/js/search-engine-settings.js
@@ -44,9 +44,14 @@ class SearchEngineSettings {
 			const seValue = key;
 			const seData = this._searchEngines[key];
 			const seOption = document.createElement('option');
-			seOption.value = seValue;
-			seOption.innerText = seData.name;
-			this._selectSearchEngine.appendChild(seOption);
+
+			// Generate search engine suggestions
+			this._selectSearchEngine.insertAdjacentHTML(
+				'beforeend',
+				`
+				<option value='${seValue}'>${seData.name}</option>
+				`
+			)
 		})
 
 		// Call to update query string and placeholder

--- a/js/weather-screen.js
+++ b/js/weather-screen.js
@@ -80,62 +80,24 @@ class WeatherScreen {
 
 	_createForecastBody = (fIcon, forecastTemp, foreDescription, fHour, fDate) => {
 
-		// Main Div
-	 	const forecastDay = document.createElement('div');
-	 	forecastDay.className = 'weatherForecastDay';
-
-	 	// Icon Container Div
-	 	const forecastIconContainer = document.createElement('div');
-	 	forecastIconContainer.className = 'weatherForecastDayIconContainer';
-
-	 	// Icon Div
-	 	const forecastIcon = document.createElement('div');
-	 	forecastIcon.className = 'weatherForecastDayIcon';
-	 	forecastIcon.style.background = `url('assets/weather-icons/${fIcon}')`;
-	 	forecastIcon.style.backgroundSize = 'cover';
-
-	 	// Details Div
-	 	const forecastDetails = document.createElement('div');
-	 	forecastDetails.className = 'weatherForecastDayDetails';
-
-	 	const forecastTemperature = document.createElement('div');
-	 	forecastTemperature.className = 'weatherForecastDayDetailsTemperature';
-	 	forecastTemperature.innerHTML = forecastTemp;
-
-	 	const forecastDescription = document.createElement('div');
-	 	forecastDescription.className = 'weatherForecastDayDetailsDescription';
-	 	forecastDescription.innerHTML = foreDescription;
-
-	 	// Append details to div container
-	 	forecastDetails.appendChild(forecastTemperature);
-	 	forecastDetails.appendChild(forecastDescription);
-
-	 	// Date Div
-	 	const forecastDayDate = document.createElement('div');
-	 	forecastDayDate.className = 'weatherForecastDayDate';
-
-	 	const forecastHour = document.createElement('div');
-	 	forecastHour.className = 'weatherForecastDayDateHour';
-	 	forecastHour.innerHTML = fHour;
-
-	 	const forecastDate = document.createElement('div');
-	 	forecastDate.className = 'weatherForecastDayDateDate';
-	 	forecastDate.innerHTML = fDate;
-
-	 	// Append icon image to div container
-	 	forecastIconContainer.appendChild(forecastIcon);
-
-	 	// Append details to div container
-	 	forecastDayDate.appendChild(forecastHour);
-	 	forecastDayDate.appendChild(forecastDate);
-
-		// Append to main div
-		forecastDay.appendChild(forecastIconContainer);
-		forecastDay.appendChild(forecastDetails);
-		forecastDay.appendChild(forecastDayDate);
-
-		// Append to the main container
-	 	this._forecastContainer.appendChild(forecastDay);
+		// Generate forecast
+	 	this._forecastContainer.insertAdjacentHTML(
+	 		'afterbegin',
+	 		`
+	 		<div class='weatherForecastDay'>
+				<div class='weatherForecastDayIconContainer'>
+					<div class='weatherForecastDayIcon' style='background: url("assets/weather-icons/${fIcon}"); background-size: cover;'></div>
+				</div>
+				<div class='weatherForecastDayDetails'>
+					<div class='weatherForecastDayDetailsTemperature'>${forecastTemp}</div>
+					<div class='weatherForecastDayDetailsDescription'>${foreDescription}</div>
+				</div><div class='weatherForecastDayDate'>
+					<div class='weatherForecastDayDateHour'>${fHour}</div>
+					<div class='weatherForecastDayDateDate'>${fDate}</div>
+				</div>
+			</div>
+	 		`
+	 	)
 	}
 
 

--- a/js/weather-screen.js
+++ b/js/weather-screen.js
@@ -82,7 +82,7 @@ class WeatherScreen {
 
 		// Generate forecast
 	 	this._forecastContainer.insertAdjacentHTML(
-	 		'afterbegin',
+	 		'beforeend',
 	 		`
 	 		<div class='weatherForecastDay'>
 				<div class='weatherForecastDayIconContainer'>

--- a/js/web-menu.js
+++ b/js/web-menu.js
@@ -72,53 +72,27 @@ class WebMenu {
 
 			const li = document.createElement('li');
 
+			li.insertAdjacentHTML(
+				'afterbegin',
+				`
+				<a class='webMenuLink' href='${url}' tabindex='-1'>
+					<div class='webItem' id='${'id' + site}'>
+						<div class='webItemContainer'>
+							<div class='webItemBody'>
+								<div class='webItemIconContainer'>
+									<div class='webItemIcon' style='background: url("assets/webcons/${icon}.svg"); background-size: cover;'></div>
+								</div>
+								<div class='webItemName'>${site}</div>
+							</div>
+						</div>
+					</div>
+				</a>
+				`
+			)
+
 			// Create callback property
 			this._createWebItemCallback(li, url);
 
-			// Create a href
-			const aWebLink = document.createElement('a');
-			aWebLink.className = 'webMenuLink';
-			aWebLink.href = url;
-			aWebLink.tabIndex = '-1';
-
-			// Create an outer div, child of li
-			let webItemDiv = document.createElement('div')
-			webItemDiv.className = 'webItem';
-			webItemDiv.id = 'id' + site;
-			
-			// Create a second div, webItemContainer
-			const webItemContainer = document.createElement('div');
-			webItemContainer.className = 'webItemContainer';
-
-			// Create the innermost div, contains icon and label
-			const webItemBody = document.createElement('div');
-			webItemBody.className = 'webItemBody';
-
-			// Create div for webItemIcon
-			const webItemIconContainer = document.createElement('div');
-			webItemIconContainer.className = 'webItemIconContainer';
-
-			const webItemIcon = document.createElement('div');
-			webItemIcon.className = 'webItemIcon';
-			webItemIcon.style.background = `url('assets/webcons/${icon}.svg')`;
-			webItemIcon.style.backgroundSize = 'cover';
-
-			// Create webItemName
-			const webItemName = document.createElement('div');
-			webItemName.className = 'webItemName';
-			webItemName.innerHTML = site;
-
-			// Append divs with heirarchy
-			webItemDiv.appendChild(webItemContainer);
-			webItemContainer.appendChild(webItemBody);
-
-			webItemIconContainer.appendChild(webItemIcon);
-			webItemBody.appendChild(webItemIconContainer);
-			webItemBody.appendChild(webItemName);
-
-			aWebLink.appendChild(webItemDiv);
-
-			li.appendChild(aWebLink);
 			this._webMenuList.appendChild(li);
 		}
 

--- a/js/web-menu.js
+++ b/js/web-menu.js
@@ -72,6 +72,7 @@ class WebMenu {
 
 			const li = document.createElement('li');
 
+			// Generate web item/li child
 			li.insertAdjacentHTML(
 				'afterbegin',
 				`


### PR DESCRIPTION
## What's new:

+ For the sake of readability, simplicity and maintainability, a bunch/dozens of `document.createElement()` and `.appendChild()`, and a "tower" of obscure code has been/will be replaced by cleaner<sup>imo</sup> `el.insertAdjacentHTML()`.